### PR TITLE
Add arbitrary options

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,15 @@ jobs:
           private_key: ${{ secrets.PRIVATE_KEY }}
           # Optional (defaults to ID of the repository's installation).
           # installation_id: 1337
+
           # Optional (defaults to the current repository).
           # repository: "owner/repo"
+
+          # Optional (no defaults).
+          # Note: only a string representation of JSON object is supported
+          # Reference: https://github.com/octokit/auth-app.js#installation-authentication
+          # options: |
+          #   { "repositoryNames": [ "foo", "bar" ] }
       - name: Use token
         env:
           TOKEN: ${{ steps.generate_token.outputs.token }}

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,8 @@ inputs:
     description: The ID of the installation for which the token will be requested (defaults to the ID of the repository's installation).
   repository:
     description: The full name of the repository for which the token will be requested (defaults to the current repository).
+  options:
+    description: Additional options for generating the token (see https://github.com/octokit/auth-app.js#installation-authentication). Must be a string with a JSON object.
 outputs:
   token:
     description: An installation token for the GitHub App on the requested repository.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-app-token",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "license": "MIT",
   "main": "dist/index.js",
   "files": [

--- a/src/fetch-installation-token.ts
+++ b/src/fetch-installation-token.ts
@@ -9,12 +9,14 @@ export const fetchInstallationToken = async ({
   owner,
   privateKey,
   repo,
+  options,
 }: Readonly<{
   appId: string;
   installationId?: number;
   owner: string;
   privateKey: string;
   repo: string;
+  options: object;
 }>): Promise<string> => {
   const app = createAppAuth({
     appId,
@@ -34,6 +36,10 @@ export const fetchInstallationToken = async ({
     } = await octokit.rest.apps.getRepoInstallation({ owner, repo }));
   }
 
-  const installation = await app({ installationId, type: "installation" });
+  const installation = await app({
+    installationId,
+    type: "installation",
+    ...options,
+  });
   return installation.token;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ const run = async () => {
 
     const installationId = getInput("installation_id");
     const repositoryInput = getInput("repository");
+    const options = getInput("options");
     const [owner, repo] = repositoryInput
       ? repositoryInput.split("/")
       : [context.repo.owner, context.repo.repo];
@@ -24,6 +25,7 @@ const run = async () => {
       owner,
       privateKey,
       repo,
+      options: options ? JSON.parse(options) : undefined,
     });
 
     setSecret(installationToken);


### PR DESCRIPTION
Add a new input that can receive arbitrary options to be passed to the auth method (reference for the available options is available at https://github.com/octokit/auth-app.js#installation-authentication)

A valid usecase is when the user want to limit the scopes available to the generated token.