### PR TITLE
Add permissions input

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,14 @@ jobs:
           private_key: ${{ secrets.PRIVATE_KEY }}
           # Optional (defaults to ID of the repository's installation).
           # installation_id: 1337
+          
           # Optional (defaults to the current repository).
           # repository: "owner/repo"
+
+          # Optional JSON object in a string (defaults to Github App permissions). See https://docs.github.com/en/rest/apps/apps#create-an-installation-access-token-for-an-app
+          # To avoid escaping the JSON quotes, use the YAML multiline line string `>-`
+          # permissions: >-
+          #   {"members": "read"}
       - name: Use token
         env:
           TOKEN: ${{ steps.generate_token.outputs.token }}

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,8 @@ inputs:
     description: The ID of the installation for which the token will be requested (defaults to the ID of the repository's installation).
   repository:
     description: The full name of the repository for which the token will be requested (defaults to the current repository).
+  permissions:
+    description: Stringified JSON object of permissions ( see https://docs.github.com/en/rest/apps/apps#create-an-installation-access-token-for-an-app )
 outputs:
   token:
     description: An installation token for the GitHub App on the requested repository.

--- a/src/fetch-installation-token.ts
+++ b/src/fetch-installation-token.ts
@@ -10,12 +10,14 @@ export const fetchInstallationToken = async ({
   owner,
   privateKey,
   repo,
+  permissions
 }: Readonly<{
   appId: string;
   installationId?: number;
   owner: string;
   privateKey: string;
   repo: string;
+  permissions: Record<string, string>;
 }>): Promise<string> => {
   const app = createAppAuth({
     appId,
@@ -42,6 +44,6 @@ export const fetchInstallationToken = async ({
     }
   }
 
-  const installation = await app({ installationId, type: "installation" });
+  const installation = await app({ installationId, permissions, type: "installation" });
   return installation.token;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,8 @@ const run = async () => {
 
     const installationId = getInput("installation_id");
     const repositoryInput = getInput("repository");
+    const permissionsJSON = getInput("permissions");
+
     const [owner, repo] = repositoryInput
       ? repositoryInput.split("/")
       : [context.repo.owner, context.repo.repo];
@@ -25,6 +27,7 @@ const run = async () => {
       owner,
       privateKey,
       repo,
+      permissions: JSON.parse(permissionsJSON)
     });
 
     setSecret(installationToken);


### PR DESCRIPTION
This PR allows to provide a `permissions` input string containing a JSON object providing the permissions as described by https://docs.github.com/en/rest/apps/apps#create-an-installation-access-token-for-an-app

I have tested it and it just works