### PR TITLE
Add github_url input defaulting to GITHUB_API_URL

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ inputs:
     description: The full name of the repository for which the token will be requested (defaults to the current repository).
   permissions:
     description: The JSON-stringified permissions granted to the token (defaults to all the GitHub app permissions, see https://docs.github.com/en/rest/apps/apps#create-an-installation-access-token-for-an-app).
-  github_url:
+  github_api_url:
     description: The API URL of the GitHub server, such as https://api.github.com. Defaults to the environment variable GITHUB_API_URL, see https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables.
 outputs:
   token:

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,8 @@ inputs:
     description: The full name of the repository for which the token will be requested (defaults to the current repository).
   permissions:
     description: The JSON-stringified permissions granted to the token (defaults to all the GitHub app permissions, see https://docs.github.com/en/rest/apps/apps#create-an-installation-access-token-for-an-app).
+  github_url:
+    description: The API URL of the GitHub server, such as https://api.github.com. Defaults to the environment variable GITHUB_API_URL, see https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables.
 outputs:
   token:
     description: An installation token for the GitHub App on the requested repository.

--- a/src/fetch-installation-token.ts
+++ b/src/fetch-installation-token.ts
@@ -1,4 +1,3 @@
-import { env } from "node:process";
 import { getOctokit } from "@actions/github";
 import { createAppAuth } from "@octokit/auth-app";
 import { request } from "@octokit/request";
@@ -11,6 +10,7 @@ export const fetchInstallationToken = async ({
   permissions,
   privateKey,
   repo,
+  baseUrl,
 }: Readonly<{
   appId: string;
   installationId?: number;
@@ -18,14 +18,13 @@ export const fetchInstallationToken = async ({
   permissions?: Record<string, string>;
   privateKey: string;
   repo: string;
+  baseUrl: URL;
 }>): Promise<string> => {
   const app = createAppAuth({
     appId,
     privateKey,
     request: request.defaults({
-      // GITHUB_API_URL is part of GitHub Actions' built-in environment variables.
-      // See https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables.
-      baseUrl: env.GITHUB_API_URL,
+      baseUrl: baseUrl.toString(),
     }),
   });
 

--- a/src/fetch-installation-token.ts
+++ b/src/fetch-installation-token.ts
@@ -5,26 +5,26 @@ import ensureError from "ensure-error";
 
 export const fetchInstallationToken = async ({
   appId,
+  baseUrl,
   installationId,
   owner,
   permissions,
   privateKey,
   repo,
-  baseUrl,
 }: Readonly<{
   appId: string;
+  baseUrl: URL;
   installationId?: number;
   owner: string;
   permissions?: Record<string, string>;
   privateKey: string;
   repo: string;
-  baseUrl: URL;
 }>): Promise<string> => {
   const app = createAppAuth({
     appId,
     privateKey,
     request: request.defaults({
-      baseUrl: baseUrl.toString(),
+      baseUrl: baseUrl.toString().replace(/\/+$/, ''),
     }),
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ const run = async () => {
 
     // GITHUB_API_URL is part of GitHub Actions' built-in environment variables.
     // See https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables.
-    const githubUrlInput = getInput("github_url");
+    const githubUrlInput = getInput("github_api_url");
     const baseUrl = githubUrlInput
       ? new URL(githubUrlInput)
       : new URL(env.GITHUB_API_URL);

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,16 +35,16 @@ const run = async () => {
     const githubUrlInput = getInput("github_api_url");
     const baseUrl = githubUrlInput
       ? new URL(githubUrlInput)
-      : new URL(env.GITHUB_API_URL);
+      : new URL(env.GITHUB_API_URL!);
 
     const installationToken = await fetchInstallationToken({
       appId,
+      baseUrl,
       installationId,
       owner,
       permissions,
       privateKey,
       repo,
-      baseUrl
     });
 
     setSecret(installationToken);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { Buffer } from "node:buffer";
+import { env } from "node:process";
 import { getInput, info, setFailed, setOutput, setSecret } from "@actions/core";
 import { context } from "@actions/github";
 import ensureError from "ensure-error";
@@ -29,6 +30,13 @@ const run = async () => {
       ? repositoryInput.split("/")
       : [context.repo.owner, context.repo.repo];
 
+    // GITHUB_API_URL is part of GitHub Actions' built-in environment variables.
+    // See https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables.
+    const githubUrlInput = getInput("github_url");
+    const baseUrl = githubUrlInput
+      ? new URL(githubUrlInput)
+      : new URL(env.GITHUB_API_URL);
+
     const installationToken = await fetchInstallationToken({
       appId,
       installationId,
@@ -36,6 +44,7 @@ const run = async () => {
       permissions,
       privateKey,
       repo,
+      baseUrl
     });
 
     setSecret(installationToken);


### PR DESCRIPTION
Resolves #42 

This adds a `github_url` parameter to the inputs so the baseUrl parameter for Octokit can be overridden. Currently it defaults to the GitHub Actions-supplied environment variable that contains the API URL for the local GitHub server. This env var cannot be overridden through any other means [because it's managed by GitHub Actions.](https://github.com/orgs/community/discussions/25649)

The input defaults to the same env var, so existing users are unaffected and this should not require a major version bump.

I added the round-trip through the URL class [to get some minimal URL validation for free](https://stackoverflow.com/a/43467144). I'm negotiable on whether this is considered valuable or it would be better to just treat it as a raw string instead, up to you.