### PR TITLE
bump actions/checkout version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
     name: Publish
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: dylanvann/publish-github-action@v1.1.49
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install
         run: yarn install --frozen-lockfile
       - name: Deduplicate dependencies


### PR DESCRIPTION
Signed-off-by: Kevin Neville <kevin@neville.se>

The current version has warnings, for instance in the [run](https://github.com/tibdex/github-app-token/actions/runs/3260241214).
I am not sure how this packages.json and actions.yml file works, where it seems like you bumped the versions, but I don't think it was enough. From PR https://github.com/tibdex/github-app-token/pull/51.