### PR TITLE
Security - Bump json5 from 1.0.1 to 1.0.2

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1924,9 +1924,9 @@ json-stable-stringify-without-jsonify@^1.0.1:
   integrity sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
 
 json5@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
-  integrity sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.2.tgz#63d98d60f21b313b77c4d6da18bfa69d80e1d593"
+  integrity sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==
   dependencies:
     minimist "^1.2.0"
 


### PR DESCRIPTION
This pull request addresses a high severity (7.1/10) security vulnerability, [CVE-2022-46175 - Prototype Pollution in JSON5 via Parse Method](https://github.com/advisories/GHSA-9c47-m6qq-7p4h), that Dependabot identified by updating the `json5` dependency.

> Bumps [json5](https://github.com/json5/json5) from 1.0.1 to 1.0.2.
> - [Release notes](https://github.com/json5/json5/releases)
> - [Changelog](https://github.com/json5/json5/blob/main/CHANGELOG.md)
> - [Commits](https://github.com/json5/json5/compare/v1.0.1...v1.0.2)
>
> ---
> updated-dependencies:
> - dependency-name: json5 dependency-type: indirect ...
>
> Signed-off-by: dependabot[bot] <support@github.com>

## See Also
- AntelopeIO/github-app-token-action [pull request 1](https://github.com/AntelopeIO/github-app-token-action/pull/1)