### PR TITLE
Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,24 @@ jobs:
         run: |
           echo "The generated token is masked: ${TOKEN}"
 ```
+
+# Release Process
+When a commit is pushed to the base branch (`main`), the [dylanvann/publish-github-action](https://github.com/DylanVann/publish-github-action) GitHub Action is invoked. If the `version` field in the `package.json` is new, then the action:
+1. Downloads dependencies.
+1. Builds the project.
+1. Packs the action as a minimal distributable.
+1. Puts these files on a branch named "`releases/`" with the version string appended to the end.
+1. Points tags corresponding to the major, minor, and patch versions at the `HEAD` of the new `release*` branch.
+
+For example, if the `version` field in `package.json` is `1.1.1`, the following refs will be created.
+- A branch named `releases/v1.1.1` with the action built and other files removed.
+- A tag named `v1.1.1` is created pointing at the `HEAD` of `releases/v1.1.1`.
+- A tag named `v1.1` is _moved_ or created, pointing at the `HEAD` of `releases/v1.1.1`.
+- A tag named `v1` is _moved_ or created, pointing at the `HEAD` of `releases/v1.1.1`.
+
+It is important to note some repo protections will prevent this action from running.
+- Tag protections.
+- Branch protections matching the release pattern.
+- Code signing requirements.
+
+If these are enforced, they must be disabled for the action to run.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ For instance, from [GitHub Actions' docs](https://docs.github.com/en/actions/usi
 A workaround is to use a [personal access token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line) from a [personal user/bot account](https://help.github.com/en/github/getting-started-with-github/types-of-github-accounts#personal-user-accounts).
 However, for organizations, GitHub Apps are [a more appropriate automation solution](https://developer.github.com/apps/differences-between-apps/#machine-vs-bot-accounts).
 
-# Examples
+## Examples
 Here is a generic example retrieving a token from a GitHub App using this action, then consuming that token in a subsequent step. You can see some of the optional inputs listed in comments, as well.
 ```yml
 jobs:
@@ -46,7 +46,7 @@ jobs:
           echo "The generated token is masked: ${TOKEN}"
 ```
 
-# Release Process
+## Release Process
 When a commit is pushed to the base branch (`main`), the [dylanvann/publish-github-action](https://github.com/DylanVann/publish-github-action) GitHub Action is invoked. If the `version` field in the `package.json` is new, then the action:
 1. Downloads dependencies.
 1. Builds the project.

--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ Don't forget to replace `${REPO_NAME}` and `${REPO_URL}` with the appropriate va
 
 The author recommends using a different GitHub App integration for each repo cloning submodules. This allows you to follow the [principle of least priviledge](https://en.wikipedia.org/wiki/Principle_of_least_privilege).
 
+Credit to [@petr-tichy](https://github.com/petr-tichy) for [the idea](https://github.com/actions/checkout/issues/287#issuecomment-1255364513), and [@matthijskooijman](https://github.com/matthijskooijman) for sharing [detailed steps to accomplish this](https://github.com/actions/checkout/issues/287#issuecomment-1315458401). Thank you both!
+
 ## Release Process
 When a commit is pushed to the base branch (`main`), the [dylanvann/publish-github-action](https://github.com/DylanVann/publish-github-action) GitHub Action is invoked. If the `version` field in the `package.json` is new, then the action:
 1. Downloads dependencies.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ For instance, from [GitHub Actions' docs](https://docs.github.com/en/actions/usi
 A workaround is to use a [personal access token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line) from a [personal user/bot account](https://help.github.com/en/github/getting-started-with-github/types-of-github-accounts#personal-user-accounts).
 However, for organizations, GitHub Apps are [a more appropriate automation solution](https://developer.github.com/apps/differences-between-apps/#machine-vs-bot-accounts).
 
+### Index
+1. [Examples](#examples)
+    1. [Cloning Private Submodules](#cloning-private-submodules)
+1. [Release Process](#release-process)
+
 ## Examples
 Here is a generic example retrieving a token from a GitHub App using this action, then consuming that token in a subsequent step. You can see some of the optional inputs listed in comments, as well.
 ```yml

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # GitHub App Token
-
 This [JavaScript GitHub Action](https://help.github.com/en/actions/building-actions/about-actions#javascript-actions) can be used to impersonate a GitHub App when `secrets.GITHUB_TOKEN`'s limitations are too restrictive and a personal access token is not suitable.
 
 For instance, from [GitHub Actions' docs](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow):

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Steps:
         steps:
           - name: Authenticate
             id: auth
-            uses: AntelopeIO/github-app-token-action@v1
+            uses: tibdex/github-app-token@v1
             with:
               app_id: ${{ secrets.${REPO_NAME}_CI_APP_ID }}
               private_key: ${{ secrets.${REPO_NAME}_CI_APP_KEY }}

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ For instance, from [GitHub Actions' docs](https://docs.github.com/en/actions/usi
 A workaround is to use a [personal access token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line) from a [personal user/bot account](https://help.github.com/en/github/getting-started-with-github/types-of-github-accounts#personal-user-accounts).
 However, for organizations, GitHub Apps are [a more appropriate automation solution](https://developer.github.com/apps/differences-between-apps/#machine-vs-bot-accounts).
 
-# Example Workflow
-
+# Examples
+Here is a generic example retrieving a token from a GitHub App using this action, then consuming that token in a subsequent step. You can see some of the optional inputs listed in comments, as well.
 ```yml
 jobs:
   job:

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "prebuild": "tsc --build",
     "build": "ncc build src/index.ts --minify  --target es2021 --v8-cache",
-    "prettier": "prettier --ignore-path .gitignore \"./**/*.{cjs,js,json,md,ts,yml}\"",
+    "prettier": "prettier --ignore-path .gitignore \"./**/*.{cjs,js,json,ts,yml}\"",
     "xo": "xo"
   },
   "dependencies": {


### PR DESCRIPTION
This pull request adds documentation explaining how to integrate this GitHub Action with a GitHub App in your organization in order to clone private submodules, as well as documentation on the release process for cutting new versions of this action.

## prettier
I also disabled `prettier` for markdown documents. It [failed](https://github.com/AntelopeIO/github-app-token-action/actions/runs/4004174981/jobs/6872988559#step:6:6) on my first documentation change with no useful feedback as to why. I looked into installing it locally to comply with your linter rules, but the `prettier` documentation explicitly warns it requires configuration in order to play nicely with `eslint`, a tool I rely on heavily for work, and I just don't have time to fight with it. I am sorry to submit a PR that does not follow your project's formatting guidelines. I hope you find the additional documentation valuable enough to accept it as-is or to help me by formatting the markdown to comply with your static analysis tool, but I understand if you do not. Thank you for your GitHub Action!

## See Also
- AntelopeIO/github-app-token-action [pull request 3](https://github.com/AntelopeIO/github-app-token-action/pull/3)

