### PR TITLE
Security - Address CVE-2022-46175 in json5

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,5 +35,8 @@
     "typescript": "^4.8.4",
     "xo": "^0.52.4",
     "yarn-deduplicate": "^5.0.0"
+  },
+  "resolutions": {
+    "json5": "^1.0.2 || ^2.2.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "prebuild": "tsc --build",
     "build": "ncc build src/index.ts --minify  --target es2021 --v8-cache",
-    "prettier": "prettier --ignore-path .gitignore \"./**/*.{cjs,js,json,md,ts,yml}\"",
+    "prettier": "prettier --ignore-path .gitignore \"./**/*.{cjs,js,md,ts,yml}\"",
     "xo": "xo"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1923,17 +1923,10 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
 
-json5@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
-  integrity sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
-  dependencies:
-    minimist "^1.2.0"
-
-json5@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.1.tgz#655d50ed1e6f95ad1a3caababd2b0efda10b395c"
-  integrity sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==
+json5@^1.0.1, "json5@^1.0.2 || ^2.2.2", json5@^2.2.1:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
+  integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
 
 jsonwebtoken@^8.5.1:
   version "8.5.1"
@@ -2173,7 +2166,7 @@ minimist-options@4.1.0:
     is-plain-obj "^1.1.0"
     kind-of "^6.0.3"
 
-minimist@^1.2.0, minimist@^1.2.6:
+minimist@^1.2.6:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.7.tgz#daa1c4d91f507390437c6a8bc01078e7000c4d18"
   integrity sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==


### PR DESCRIPTION
This pull request attempts to address [CVE-2022-46175 - Prototype Pollution in JSON5 via Parse Method](https://github.com/advisories/GHSA-9c47-m6qq-7p4h) by using the `resolutions` field in the `package.json` to force `yarn` to select a version of this transitive dependency that has been patched for this CVE regardless of what version the parent dependency is asking for.

I believe this is a reasonable approach because the difference between what was requested and what is forced is only one or two patch versions.
```diff
-json5@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
-  integrity sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
-  dependencies:
-    minimist "^1.2.0"
-
-json5@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.1.tgz#655d50ed1e6f95ad1a3caababd2b0efda10b395c"
-  integrity sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==
+json5@^1.0.1, "json5@^1.0.2 || ^2.2.2", json5@^2.2.1:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
+  integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
```
That being said, a better solution would be to update the parents causing the transitive dependencies requesting the old package version instead of using `resolutions`.
```
eslint-plugin-import@2.26.0 requires json5@^1.0.1 via a transitive dependency on tsconfig-paths@3.14.1
xo@0.52.4 requires json5@^1.0.1 via a transitive dependency on tsconfig-paths@3.14.1
```

## See Also
- AntelopeIO/github-app-token-action [pull request 4](https://github.com/AntelopeIO/github-app-token-action/pull/4)


