### PR TITLE
Print the Action Version Being Run

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ const run = async () => {
     const rawPackageJson = readFileSync("../package.json", {
       encoding: "utf8",
     });
-    const version: string = JSON.parse(rawPackageJson).version;
+    const { version } = (JSON.parse(rawPackageJson) as { version: string });
     info(`Running github-app-token v${version}.`);
 
     const appId = getInput("app_id", { required: true });

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,9 @@ import ensureError from "ensure-error";
 import isBase64 from "is-base64";
 import { fetchInstallationToken } from "./fetch-installation-token.js";
 
+const packageJson = require('../package.json');
+info(`Running github-app-token v${packageJson.version}.`);
+
 const run = async () => {
   try {
     const appId = getInput("app_id", { required: true });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,16 @@
 import { Buffer } from "node:buffer";
 import { getInput, info, setFailed, setOutput, setSecret } from "@actions/core";
 import ensureError from "ensure-error";
+import * as fs from 'fs'
 import isBase64 from "is-base64";
 import { fetchInstallationToken } from "./fetch-installation-token.js";
 
-const packageJson = require('../package.json');
-info(`Running github-app-token v${packageJson.version}.`);
-
 const run = async () => {
   try {
+    const rawPackageJson = fs.readFileSync('../package.json', { encoding: 'utf8' });
+    const { version } = JSON.parse(rawPackageJson);
+    info(`Running github-app-token v${version}.`);
+
     const appId = getInput("app_id", { required: true });
 
     const installationIdInput = getInput("installation_id");

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,9 @@ import { fetchInstallationToken } from "./fetch-installation-token.js";
 
 const run = async () => {
   try {
-    const rawPackageJson = readFileSync("../package.json", { encoding: "utf8" });
+    const rawPackageJson = readFileSync("../package.json", {
+      encoding: "utf8",
+    });
     const { version } = JSON.parse(rawPackageJson);
     info(`Running github-app-token v${version}.`);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,8 +10,8 @@ const run = async () => {
     const rawPackageJson = readFileSync("../package.json", {
       encoding: "utf8",
     });
-    const { version } = JSON.parse(rawPackageJson);
-    info(`Running github-app-token v${version}.`);
+    const packageJSON = JSON.parse(rawPackageJson);
+    info(`Running github-app-token v${packageJSON.version}.`);
 
     const appId = getInput("app_id", { required: true });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,13 @@
 import { Buffer } from "node:buffer";
 import { getInput, info, setFailed, setOutput, setSecret } from "@actions/core";
 import ensureError from "ensure-error";
-import * as fs from "fs";
+import { readFileSync } from "fs";
 import isBase64 from "is-base64";
 import { fetchInstallationToken } from "./fetch-installation-token.js";
 
 const run = async () => {
   try {
-    const rawPackageJson = fs.readFileSync("../package.json", { encoding: "utf8" });
+    const rawPackageJson = readFileSync("../package.json", { encoding: "utf8" });
     const { version } = JSON.parse(rawPackageJson);
     info(`Running github-app-token v${version}.`);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,8 +10,8 @@ const run = async () => {
     const rawPackageJson = readFileSync("../package.json", {
       encoding: "utf8",
     });
-    const packageJSON = JSON.parse(rawPackageJson);
-    info(`Running github-app-token v${packageJSON.version}.`);
+    const version: string = JSON.parse(rawPackageJson).version;
+    info(`Running github-app-token v${version}.`);
 
     const appId = getInput("app_id", { required: true });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,13 @@
 import { Buffer } from "node:buffer";
 import { getInput, info, setFailed, setOutput, setSecret } from "@actions/core";
 import ensureError from "ensure-error";
-import * as fs from 'fs'
+import * as fs from "fs";
 import isBase64 from "is-base64";
 import { fetchInstallationToken } from "./fetch-installation-token.js";
 
 const run = async () => {
   try {
-    const rawPackageJson = fs.readFileSync('../package.json', { encoding: 'utf8' });
+    const rawPackageJson = fs.readFileSync("../package.json", { encoding: "utf8" });
     const { version } = JSON.parse(rawPackageJson);
     info(`Running github-app-token v${version}.`);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { Buffer } from "node:buffer";
+import { readFileSync } from "node:fs";
 import { getInput, info, setFailed, setOutput, setSecret } from "@actions/core";
 import ensureError from "ensure-error";
-import { readFileSync } from "fs";
 import isBase64 from "is-base64";
 import { fetchInstallationToken } from "./fetch-installation-token.js";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ const run = async () => {
     const rawPackageJson = readFileSync("../package.json", {
       encoding: "utf8",
     });
-    const { version } = (JSON.parse(rawPackageJson) as { version: string });
+    const { version } = JSON.parse(rawPackageJson) as { version: string };
     info(`Running github-app-token v${version}.`);
 
     const appId = getInput("app_id", { required: true });


### PR DESCRIPTION
This pull request adds code that prints the version of the GitHub Action being run, for debugging reasons. For example, this would be helpful if an action is pinned to a major version (`@v1`) and behavior changes because a new version was published upstream.

