### PR TITLE
Revert Node.js update

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ outputs:
   token:
     description: An installation token for the GitHub App on the requested repository.
 runs:
-  using: node20
+  using: node16
   main: dist/index.js
 branding:
   icon: unlock

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-app-token",
-  "version": "1.8.0",
+  "version": "1.8.2",
   "license": "MIT",
   "type": "module",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-app-token",
-  "version": "1.8.1",
+  "version": "1.8.0",
   "license": "MIT",
   "type": "module",
   "files": [


### PR DESCRIPTION
See https://github.com/tibdex/github-app-token/pull/81#issuecomment-1701581938. I need more time to assess this change. Projects willing to use Node.js 20 can use `1.8.1`.