### PR TITLE
fix/node version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -45,7 +45,7 @@ outputs:
   token:
     description: An installation access token for the GitHub App.
 runs:
-  using: node20
+  using: node16
   main: dist/main/index.js
   post: dist/post/index.js
 branding:


### PR DESCRIPTION
Following the action gives the following error:

```
Error: System.ArgumentOutOfRangeException: Specified
argument was out of the range of valid values. (Parameter
''using: node20' is not supported, use 'docker', 'node12' or 'node16' instead.')
at GitHub.Runner.Worker.ActionManifestManager.
ConvertRuns(IExecutionContext executionContext, TemplateContext
templateContext, TemplateToken inputsToken, String fileRelativePath,
MappingToken outputs)
at GitHub.Runner.Worker.ActionManifestManager.Load(IExecutionContext
executionContext, String manifestFile)
Error: Fail to load tibdex/github-app-token/v1/action.yml
```

Changing the node version seems the way to fix this.