### PR TITLE
docs: fix the example of the input `repositories`

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,9 @@ jobs:
           private_key: ${{ secrets.PRIVATE_KEY }}
 
           # Optional.
+          # List of repository names that the token should have access to.
           # repositories: >-
-          #   ["actions/toolkit", "github/docs"]
+          #   ["github-app-token"]
 
           # Optional.
           # revoke: false

--- a/action.yml
+++ b/action.yml
@@ -38,7 +38,7 @@ inputs:
     required: true
   repositories:
     description: >-
-      The JSON-stringified array of the full names of the repositories the token should have access to.
+      The JSON-stringified array of the names of the repositories the token should have access to.
       Defaults to all repositories that the installation can access.
       See https://docs.github.com/en/rest/apps/apps?apiVersion=2022-11-28#create-an-installation-access-token-for-an-app's `repositories`.
   revoke:


### PR DESCRIPTION
Close #105

`repositories` must be a list of repository names.
Repository full names such as `github/docs` are invalid.
