### PR TITLE
feat: Add an optional input `repository_ids`

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ jobs:
           # https://docs.github.com/en/rest/apps/apps?apiVersion=2022-11-28#create-an-installation-access-token-for-an-app
           # https://docs.github.com/en/actions/learn-github-actions/contexts#github-context
           # repository_ids: >-
-          #   ["${{github.repository_id}}"]
+          #   [${{github.repository_id}}]
 
           # Optional.
           # revoke: false

--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ jobs:
           #   ["actions/toolkit", "github/docs"]
 
           # Optional.
+          # List of repository IDs that the token should have access to
+          # https://docs.github.com/en/rest/apps/apps?apiVersion=2022-11-28#create-an-installation-access-token-for-an-app
+          # https://docs.github.com/en/actions/learn-github-actions/contexts#github-context
+          # repository_ids: >-
+          #   ["${{github.repository_id}}"]
+
+          # Optional.
           # revoke: false
 
       - run: "echo 'The created token is masked: ${{ steps.create_token.outputs.token }}'"

--- a/action.yml
+++ b/action.yml
@@ -41,6 +41,11 @@ inputs:
       The JSON-stringified array of the full names of the repositories the token should have access to.
       Defaults to all repositories that the installation can access.
       See https://docs.github.com/en/rest/apps/apps?apiVersion=2022-11-28#create-an-installation-access-token-for-an-app's `repositories`.
+  repository_ids:
+    description: >-
+      The JSON-stringified array of the ids of the repositories the token should have access to.
+      Defaults to all repositories that the installation can access.
+      See https://docs.github.com/en/rest/apps/apps?apiVersion=2022-11-28#create-an-installation-access-token-for-an-app's `repository_ids`.
   revoke:
     description: Revoke the token at the end of the job.
     default: true

--- a/src/create-installation-access-token.ts
+++ b/src/create-installation-access-token.ts
@@ -14,7 +14,7 @@ export type InstallationAccessTokenCreationOptions = Readonly<{
   permissions?: Record<string, string>;
   privateKey: string;
   repositories?: string[];
-  repositoryIDs?: string[];
+  repositoryIDs?: number[];
 }>;
 
 export const createInstallationAccessToken = async ({

--- a/src/create-installation-access-token.ts
+++ b/src/create-installation-access-token.ts
@@ -50,7 +50,12 @@ export const createInstallationAccessToken = async ({
       data: { token },
     } = await octokit.request(
       "POST /app/installations/{installation_id}/access_tokens",
-      { installation_id: installationId, permissions, repositories, repository_ids: repositoryIDs },
+      {
+        installation_id: installationId,
+        permissions,
+        repositories,
+        repository_ids: repositoryIDs,
+      },
     );
     return token;
   } catch (error: unknown) {

--- a/src/create-installation-access-token.ts
+++ b/src/create-installation-access-token.ts
@@ -14,6 +14,7 @@ export type InstallationAccessTokenCreationOptions = Readonly<{
   permissions?: Record<string, string>;
   privateKey: string;
   repositories?: string[];
+  repositoryIDs?: string[];
 }>;
 
 export const createInstallationAccessToken = async ({
@@ -23,6 +24,7 @@ export const createInstallationAccessToken = async ({
   permissions,
   privateKey,
   repositories,
+  repositoryIDs,
 }: InstallationAccessTokenCreationOptions): Promise<string> => {
   try {
     const app = createAppAuth({
@@ -48,7 +50,7 @@ export const createInstallationAccessToken = async ({
       data: { token },
     } = await octokit.request(
       "POST /app/installations/{installation_id}/access_tokens",
-      { installation_id: installationId, permissions, repositories },
+      { installation_id: installationId, permissions, repositories, repository_ids: repositoryIDs },
     );
     return token;
   } catch (error: unknown) {

--- a/src/parse-options.ts
+++ b/src/parse-options.ts
@@ -48,7 +48,7 @@ export const parseOptions = (): InstallationAccessTokenCreationOptions => {
 
   const repositoryIDsInput = getInput("repository_ids");
   const repositoryIDs = repositoryIDsInput
-    ? (JSON.parse(repositoryIDsInput) as string[])
+    ? (JSON.parse(repositoryIDsInput) as number[])
     : undefined;
   debug(`Requested repository_ids: ${JSON.stringify(repositoryIDs)}.`);
 

--- a/src/parse-options.ts
+++ b/src/parse-options.ts
@@ -46,6 +46,12 @@ export const parseOptions = (): InstallationAccessTokenCreationOptions => {
     : undefined;
   debug(`Requested repositories: ${JSON.stringify(repositories)}.`);
 
+  const repositoryIDsInput = getInput("repository_ids");
+  const repositoryIDs = repositoryIDsInput
+    ? (JSON.parse(repositoryIDsInput) as string[])
+    : undefined;
+  debug(`Requested repository_ids: ${JSON.stringify(repositoryIDs)}.`);
+
   return {
     appId,
     githubApiUrl,
@@ -53,5 +59,6 @@ export const parseOptions = (): InstallationAccessTokenCreationOptions => {
     permissions,
     privateKey,
     repositories,
+    repositoryIDs,
   };
 };


### PR DESCRIPTION
Close #106

## Test

I tested this pull request with the fork version.

- https://github.com/suzuki-shunsuke/github-app-token/releases/tag/v2.2.0

It works well.

### Test 1. Use `repository_ids`

https://github.com/suzuki-shunsuke/test-github-action/actions/runs/6993168247/job/19025551390?pr=184

```
Run suzuki-shunsuke/github-app-token@v2.2.0
  with:
    app_id: ***
    private_key: ***
    permissions: {"pull_requests": "write", "issues": "write", "contents": "write"}
    repository_ids: [221882701]
    github_api_url: https://api.github.com
    installation_retrieval_mode: repository
    installation_retrieval_payload: suzuki-shunsuke/test-github-action
    revoke: true
Token created successfully
```


### Test 2. Don't use `repository_ids`

https://github.com/suzuki-shunsuke/test-github-action/actions/runs/6993181859/job/19025581353

```
Run suzuki-shunsuke/github-app-token@v2.2.0
  with:
    app_id: ***
    private_key: ***
    permissions: {"pull_requests": "write", "issues": "write", "contents": "write"}
    github_api_url: https://api.github.com
    installation_retrieval_mode: repository
    installation_retrieval_payload: suzuki-shunsuke/test-github-action
    revoke: true
Token created successfully
```